### PR TITLE
Expose `valve_position` for compatible thermostats

### DIFF
--- a/lib/extension/homeassistant.js
+++ b/lib/extension/homeassistant.js
@@ -110,6 +110,15 @@ const cfg = {
             value_template: '{{ value_json.linkquality }}',
         },
     },
+    'sensor_valve_position': {
+        type: 'sensor',
+        object_id: 'valve_position',
+        discovery_payload: {
+            icon: 'mdi:valve',
+            unit_of_measurement: '%',
+            value_template: '{{ value_json.position }}',
+        },
+    },
 
     // Switch
     'switch_window_detection': {
@@ -331,7 +340,11 @@ const manualMaping = {
     'RC-2000WH': [climate(10, 30, 'occupied_heating_setpoint', 1, ['off', 'auto', 'heat', 'cool'],
         ['auto', 'on', 'smart'], [], true, true)],
     'TS0601_thermostat': [
-        cfg.lock_child_lock, cfg.switch_window_detection, cfg.switch_valve_detection, cfg.sensor_battery,
+        cfg.lock_child_lock,
+        cfg.switch_window_detection,
+        cfg.switch_valve_detection,
+        cfg.sensor_battery,
+        cfg.sensor_valve_position,
         climate(5, 30, 'current_heating_setpoint', 0.5, [], [],
             ['schedule', 'manual', 'away', 'boost', 'complex', 'comfort', 'eco']),
     ],


### PR DESCRIPTION
This exposes an absolute position, which is number between 0% and 100%.

This allows to monitor how much open or closed is valve.
